### PR TITLE
d

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.6
+        uses: dependabot/fetch-metadata@v1.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve PR

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.5
+        uses: dependabot/fetch-metadata@v1.3.6
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve PR

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.5
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable Auto-Merge
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
 # Checkout source code
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
 # Cache maven stuff
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,26 +40,6 @@ jobs:
     - name: Build and test
       run: ./build/build.sh
 
-    - name: Generate Jacoco Badge
-      id: jacoco
-      uses: cicirello/jacoco-badge-generator@v1.0.0
-      with:
-        jacoco-csv-file: target/site/jacoco/jacoco.csv
-
-    - name: Log coverage percentage
-      run: |
-        echo "coverage = ${{ steps.jacoco.outputs.coverage }}"
-
-    - name: Update coverage badge
-      if: ${{ steps.tag.conclusion == 'skipped' }}
-      run: ./build/badge-update.sh
-
-    - name: Upload Jacoco coverage report
-      uses: actions/upload-artifact@v2
-      with:
-        name: jacoco-report
-        path: target/site/jacoco/
-
     - name: Deploy
       if: ${{ steps.tag.conclusion != 'skipped' }}
       run: ./build/maven-run.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,8 @@ jobs:
       run: ./build/maven-run.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        SIGN_KEY: ${{ secrets.MAVEN_SIGN_KEY }}
+        SIGN_KEY_ID: ${{ secrets.MAVEN_SIGN_KEY_ID }}
+        SIGN_KEY_PASS: ${{ secrets.MAVEN_KEY_PASSPHRASE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 # Checkout source code
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'adopt'

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request: ~
 
 jobs:
-  build:
+  pr_build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -8,21 +8,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-# Checkout source code
-    - uses: actions/checkout@v2
+      # Checkout source code
+      - uses: actions/checkout@v3
 
-# Cache maven stuff
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+      # Cache maven stuff
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
-    - name: Build and test
-      run: ./build/build.sh
+      - name: Build and test
+        run: ./build/build.sh
 
-    - name: Log coverage percentage
-      run: |
-        echo "coverage = ${{ steps.jacoco.outputs.coverage }}"
+      - name: Upload Jacoco coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco-report
+          path: target/site/jacoco-aggregate/
+
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr
+          path: |
+            pr/
+            target/site/jacoco-aggregate/jacoco.csv

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: jacoco-report
-          path: target/site/jacoco-aggregate/
+          path: target/site/jacoco/
 
       - name: Save PR number
         run: |
@@ -39,4 +39,4 @@ jobs:
           name: pr
           path: |
             pr/
-            target/site/jacoco-aggregate/jacoco.csv
+            target/site/jacoco/jacoco.csv

--- a/.github/workflows/pr_ci_coverage.yaml
+++ b/.github/workflows/pr_ci_coverage.yaml
@@ -1,0 +1,63 @@
+name: Update coverage
+
+on:
+  workflow_run:
+    workflows: ["Pull Request CI"]
+    types:
+      - completed
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}    
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - name: Generate Jacoco Badge
+        id: jacoco
+        uses: cicirello/jacoco-badge-generator@v2.8.1
+        with:
+          jacoco-csv-file: target/site/jacoco-aggregate/jacoco.csv
+
+      - name: Log coverage percentage
+        run: |
+          echo "coverage = ${{ steps.jacoco.outputs.coverage }}"  
+
+      #      - name: Update coverage badge
+      #        run: ./build/badge-update.sh
+
+      - name: 'Comment on PR with code coverage'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./pr/NR'));
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: 'Code coverage after this PR: ' + ${{ steps.jacoco.outputs.coverage }}
+            });

--- a/.github/workflows/pr_ci_coverage.yaml
+++ b/.github/workflows/pr_ci_coverage.yaml
@@ -39,7 +39,7 @@ jobs:
         id: jacoco
         uses: cicirello/jacoco-badge-generator@v2.8.1
         with:
-          jacoco-csv-file: target/site/jacoco-aggregate/jacoco.csv
+          jacoco-csv-file: target/site/jacoco/jacoco.csv
 
       - name: Log coverage percentage
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dk.kvalitetsit</groupId>
 	<artifactId>spring-prometheus-app-info</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -16,7 +16,7 @@
 
 	<scm>
 		<connection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</connection>
-		<tag>v2.0.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.4</version>
+		<version>3.0.5</version>
 	</parent>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -133,21 +133,6 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.5</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
 				<configuration>
 					<tagNameFormat>v@{project.version}</tagNameFormat>
@@ -172,6 +157,18 @@
 				</configuration>
 			</plugin>
 
+			<plugin>
+				<groupId>org.simplify4u.plugins</groupId>
+				<artifactId>sign-maven-plugin</artifactId>
+				<version>1.0.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dk.kvalitetsit</groupId>
 	<artifactId>spring-prometheus-app-info</artifactId>
-	<version>1.2.1-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.0</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dk.kvalitetsit</groupId>
 	<artifactId>spring-prometheus-app-info</artifactId>
-	<version>1.1.1-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.0</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<properties>
@@ -92,7 +92,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
+				<version>3.0.0</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
+				<version>3.0.0</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 	</developers>
 
 	<properties>
-		<jacoco.version>0.8.8</jacoco.version>
+		<jacoco.version>0.8.9</jacoco.version>
 	</properties>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dk.kvalitetsit</groupId>
 	<artifactId>spring-prometheus-app-info</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -16,7 +16,7 @@
 
 	<scm>
 		<connection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</connection>
-		<tag>v1.2.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,22 +10,46 @@
 		<version>3.0.4</version>
 	</parent>
 
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>Exposes information about application version to Spring Actuator Prometheus scrape endpoint.</description>
+	<url>https://github.com/KvalitetsIT/spring-prometheus-app-info</url>
+
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Jonas Pedersen</name>
+			<email>jpe@kvalitetsit.dk</email>
+			<organization>KvalitetsIT</organization>
+			<organizationUrl>https://kvalitetsit.dk</organizationUrl>
+		</developer>
+	</developers>
+
 	<properties>
 		<jacoco.version>0.8.8</jacoco.version>
 	</properties>
 
-	<scm>
-		<connection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</connection>
-		<tag>HEAD</tag>
-	</scm>
-
 	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
 		<repository>
-			<id>github</id>
-			<name>GitHub Packages</name>
-			<url>https://maven.pkg.github.com/KvalitetsIT/spring-prometheus-app-info</url>
+			<id>ossrh</id>
+			<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
+
+	<scm>
+		<connection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</connection>
+		<developerConnection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</developerConnection>
+		<url>https://github.com/KvalitetsIT/spring-prometheus-app-info</url>
+		<tag>v2.0.0</tag>
+	</scm>
 
 	<dependencyManagement>
 		<dependencies>
@@ -91,8 +115,13 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-install-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dk.kvalitetsit</groupId>
 	<artifactId>spring-prometheus-app-info</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0</version>
+		<version>2.7.0</version>
 	</parent>
 
 	<properties>
@@ -92,7 +92,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>2.8.2</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.3</version>
+		<version>3.0.4</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dk.kvalitetsit</groupId>
 	<artifactId>spring-prometheus-app-info</artifactId>
-	<version>2.0.1</version>
+	<version>2.0.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -45,7 +45,7 @@
 		<connection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</connection>
 		<developerConnection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</developerConnection>
 		<url>https://github.com/KvalitetsIT/spring-prometheus-app-info</url>
-		<tag>v2.0.1</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.0.3</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dk.kvalitetsit</groupId>
 	<artifactId>spring-prometheus-app-info</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.0</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -16,7 +16,7 @@
 
 	<scm>
 		<connection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</connection>
-		<tag>HEAD</tag>
+		<tag>v2.0.0</tag>
 	</scm>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0</version>
+		<version>3.0.1</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.1</version>
+		<version>3.0.2</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
 						</goals>
 					</execution>
 				</executions>
+				<version>3.1.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dk.kvalitetsit</groupId>
 	<artifactId>spring-prometheus-app-info</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.0.1</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -20,10 +20,11 @@
 			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
+
 	<developers>
 		<developer>
-			<name>Jonas Pedersen</name>
-			<email>jpe@kvalitetsit.dk</email>
+			<name>KvalitetsIT</name>
+			<email>development@kvalitetsit.dk</email>
 			<organization>KvalitetsIT</organization>
 			<organizationUrl>https://kvalitetsit.dk</organizationUrl>
 		</developer>
@@ -38,17 +39,13 @@
 			<id>ossrh</id>
 			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
 	</distributionManagement>
 
 	<scm>
 		<connection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</connection>
 		<developerConnection>scm:git:git@github.com:KvalitetsIT/spring-prometheus-app-info.git</developerConnection>
 		<url>https://github.com/KvalitetsIT/spring-prometheus-app-info</url>
-		<tag>v2.0.0</tag>
+		<tag>v2.0.1</tag>
 	</scm>
 
 	<dependencyManagement>
@@ -106,6 +103,49 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.2.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.9.1</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.5</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
@@ -113,16 +153,25 @@
 					<tagNameFormat>v@{project.version}</tagNameFormat>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-				<version>3.0.0</version>
-			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>3.1.1</version>
 			</plugin>
+
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>1.6.13</version>
+				<extensions>true</extensions>
+				<configuration>
+					<serverId>ossrh</serverId>
+					<nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+				</configuration>
+			</plugin>
+
 		</plugins>
 	</build>
 </project>

--- a/src/main/java/dk/kvalitetsit/prometheus/app/info/actuator/configuration/ActuatorAppInfoAutoConfiguration.java
+++ b/src/main/java/dk/kvalitetsit/prometheus/app/info/actuator/configuration/ActuatorAppInfoAutoConfiguration.java
@@ -6,14 +6,14 @@ import dk.kvalitetsit.prometheus.app.info.actuator.VersionInfoContributor;
 import dk.kvalitetsit.prometheus.app.info.actuator.VersionProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 import java.util.List;
 
-@Configuration
+@AutoConfiguration
 @PropertySource("actuator.properties")
 @PropertySource(value = "actuator-custom.properties", ignoreResourceNotFound = true)
 @PropertySource(value = "git.properties", ignoreResourceNotFound = true)

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dk.kvalitetsit.prometheus.app.info.actuator.configuration.ActuatorAppInfoAutoConfiguration


### PR DESCRIPTION
- Support Spring Boot 3.
- Bump actions/setup-java from 2 to 3
- Bump maven-deploy-plugin from 2.8.2 to 3.0.0
- Bump actions/cache from 2 to 3.0.11
- Bump actions/checkout from 2 to 3.1.0
- [maven-release-plugin] rollback the release of v1.2.0
- Revert "[maven-release-plugin] rollback the release of v1.2.0"
- [maven-release-plugin] prepare release v2.0.0
- [maven-release-plugin] prepare for next development iteration
- Fix code coverage.
- Bump spring-boot-starter-parent from 3.0.0 to 3.0.1
- Bump spring-boot-starter-parent from 3.0.1 to 3.0.2
- Bump dependabot/fetch-metadata from 1.3.5 to 1.3.6
- Bump maven-deploy-plugin from 3.0.0 to 3.1.0
- Bump spring-boot-starter-parent from 3.0.2 to 3.0.3
- Bump spring-boot-starter-parent from 3.0.3 to 3.0.4
- Fix
- Prepare for central maven upload.
- Change signing plugin.
- Bump jacoco-maven-plugin from 0.8.8 to 0.8.9
- Bump spring-boot-starter-parent from 3.0.4 to 3.0.5
- Bump maven-deploy-plugin from 3.1.0 to 3.1.1
- Bump dependabot/fetch-metadata from 1.3.6 to 1.4.0
- Set correct version in pom.xml.
